### PR TITLE
Fix error with chase cars and landing_marker.

### DIFF
--- a/js/tracker.js
+++ b/js/tracker.js
@@ -1549,6 +1549,7 @@ function addPosition(position) {
     if(!vehicles.hasOwnProperty(vcallsign)) {
         var marker = null;
         var marker_shadow = null;
+        var landing_marker = null;
         var vehicle_type = "";
         var horizon_circle = null;
         var subhorizon_circle = null;
@@ -1729,6 +1730,8 @@ function addPosition(position) {
                         title: vcallsign + " Onboard Landing Prediction"
                     });
                     gmaps_elements.push(landing_marker);
+                } else {
+                    landing_marker = null;
                 }
             } else {
                 landing_marker = null;


### PR DESCRIPTION
Fix a bug I introduced through not testing with chase cars on the map. 
In short, landing_marker was only initialised if the vehicle was a balloon, resulting in things breaking if the vehicle was a chase car. 
This is now fixed by landing_marker being initialised to null along with the other markers up the top of that section.