### PR TITLE
Add 1 hour filter for TTN receivers.

### DIFF
--- a/js/tracker.js
+++ b/js/tracker.js
@@ -2714,6 +2714,12 @@ function updateReceivers(r) {
 
         if(lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
 
+        // Filter out any receivers that are from the TTN Bridge code, and that are older than 1 hour.
+        // This helps de-clutter the map during launches utilising TTN, and that result in *many* new 
+        // receivers showing up on the map.
+        var age = parseFloat(r[i].tdiff_hours); // Grab age of the receiver.
+        if(r[i].description.includes('TTN_LORAWAN_GW') && age > 1.0) continue;
+
         var r_index = $.inArray(r[i].name, receiver_names);
 
         if(r_index == -1) {


### PR DESCRIPTION
This helps keep the map de-cluttered of receivers during and after flights utilising The Things Network. The required changes to the habitat-transition backend have been merged and deployed already ( https://github.com/ukhas/habitat-transition/pull/17 ).